### PR TITLE
Add macOS app build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Please rest assured — the tool is safe to use, or you can add it to your antiv
 ## 🖱️ GUI 工具（適合一般使用者）| GUI Tool for Everyone
 📦 [點我下載免安裝版本](https://github.com/TengWei-Hung/PhotoOrganizer/releases/download/v1.0.0/PhotoOrganizer_GUI_v1.0.zip)
 
+### macOS `.app` build
+想在 macOS 上使用 GUI？請安裝 `pyinstaller` 並執行：
+
+```bash
+pip install pyinstaller
+bash scripts/build_mac_gui.sh
+```
+成功後會在 `dist/` 資料夾取得 `PhotoOrganizer.app` 以及壓縮檔。
+
 ### `photo_gui_launcher.exe`
 如果你不會寫程式，只要雙擊這個執行檔就能開始使用。  
 If you're not familiar with Python — just double-click to run!

--- a/scripts/build_mac_gui.sh
+++ b/scripts/build_mac_gui.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Build PhotoOrganizer GUI for macOS using PyInstaller
+# Requires: pip install pyinstaller
+set -e
+
+pyinstaller --noconfirm --windowed --name PhotoOrganizer gui/photo_gui_launcher.py
+
+if [ -d dist/PhotoOrganizer.app ]; then
+    (cd dist && zip -r PhotoOrganizer_mac.zip PhotoOrganizer.app)
+fi


### PR DESCRIPTION
## Summary
- allow building PhotoOrganizer GUI as a macOS `.app`
- document how to build the macOS version

## Testing
- `python -m py_compile gui/photo_gui_launcher.py scripts/organize_photo_by_year.py scripts/organize_photo_by_month.py scripts/organize_photo_by_date.py scripts/organize_photo_by_month_from_date.py`
- `bash scripts/build_mac_gui.sh` *(fails: pyinstaller not found)*

------
https://chatgpt.com/codex/tasks/task_e_684174e363048330ad008103a7ef1f2c